### PR TITLE
Not overwrite conf region when awsconfig is empty.

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,10 @@ func main() {
 	}
 
 	opt := optionsFromFile()
-	opt.Region = loadRegionInAwsConfig()
+	awsConfigRegion := loadRegionInAwsConfig()
+	if awsConfigRegion != "" {
+		opt.Region = awsConfigRegion
+	}
 	// merge optoins from cmdline
 	if *filters != "" {
 		for k, v := range parseFilterString(*filters) {


### PR DESCRIPTION
When I used ls-hosts in AWS EC2 with IAM Role,
`MissingRegion: could not find region configuration` has occurred.
I had set region in .ls-hosts configuration, but there was no .aws/config.
When there was no .aws/config, I want to use .ls-hosts configuration.

.ls-hosts configでregionを設定していても.aws/configが存在しない場合にregionが空設定されるので、
.aws/configの結果が空でない場合のみ上書きするようにしました。