### PR TITLE
Initialize empty filters

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -35,6 +35,13 @@ type Options struct {
 	Noheader    bool
 }
 
+func NewOptions() *Options {
+	opt := &Options{}
+	opt.Filters = make(map[string]string)
+	opt.TagFilters = make(map[string]string)
+	return opt
+}
+
 func (o *Options) FieldNames() []string {
 	if len(o.Fields) > 1 {
 		return o.Fields

--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func parseFieldsString(str string) []string {
 }
 
 func optionsFromFile() *client.Options {
-	opt := &client.Options{}
+	opt := client.NewOptions()
 	if cfg, err := loadConfig(); err == nil {
 		opt.Region = cfg.Section("options").Key("region").Value()
 		opt.TagFilters = parseFilterString(cfg.Section("options").Key("tags").Value())
@@ -99,7 +99,6 @@ func main() {
 		opt.Region = awsConfigRegion
 	}
 	// merge optoins from cmdline
-	opt.Filters = make(map[string]string)
 	if *filters != "" {
 		for k, v := range parseFilterString(*filters) {
 			opt.Filters[k] = v

--- a/main.go
+++ b/main.go
@@ -99,6 +99,7 @@ func main() {
 		opt.Region = awsConfigRegion
 	}
 	// merge optoins from cmdline
+	opt.Filters = make(map[string]string)
 	if *filters != "" {
 		for k, v := range parseFilterString(*filters) {
 			opt.Filters[k] = v


### PR DESCRIPTION
When I used filters argument, ls-hosts is crashed. error message is below,
```
panic: assignment to entry in nil map

goroutine 1 [running]:
panic(0x8521a0, 0xc82000d770)
        /usr/local/go/src/runtime/panic.go:481 +0x3e6
main.main()
        /data/src/github.com/ReSTARTR/ec2-ls-hosts/main.go:104 +0x4bd
```

Initialize empty `opt.Filters` map.